### PR TITLE
Move tsx from dependencies to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "express": "^5.0.0",
-        "tsx": "^4.0.0"
+        "express": "^5.0.0"
       },
       "devDependencies": {
         "@types/express": "^5.0.0",
         "@types/node": "^22.0.0",
+        "tsx": "^4.0.0",
         "typescript": "^5.7.0",
         "vite": "^6.0.0",
         "vitest": "^3.0.0"
@@ -27,6 +27,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -43,6 +44,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -59,6 +61,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -75,6 +78,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -91,6 +95,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -107,6 +112,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -123,6 +129,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -139,6 +146,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -155,6 +163,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -171,6 +180,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -187,6 +197,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -203,6 +214,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -219,6 +231,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -235,6 +248,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -251,6 +265,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -267,6 +282,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -283,6 +299,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -299,6 +316,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -315,6 +333,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -331,6 +350,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -347,6 +367,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -363,6 +384,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -379,6 +401,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -395,6 +418,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -411,6 +435,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -427,6 +452,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1299,6 +1325,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -1475,6 +1502,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1535,6 +1563,7 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -1923,6 +1952,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -2245,6 +2275,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",

--- a/package.json
+++ b/package.json
@@ -39,12 +39,12 @@
   "devDependencies": {
     "@types/express": "^5.0.0",
     "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
     "typescript": "^5.7.0",
     "vite": "^6.0.0",
     "vitest": "^3.0.0"
   },
   "dependencies": {
-    "express": "^5.0.0",
-    "tsx": "^4.0.0"
+    "express": "^5.0.0"
   }
 }

--- a/todo.md
+++ b/todo.md
@@ -9,8 +9,9 @@ Implement logic for captcha cookie.
 
 ## Improvement tasks
 
-### 1. Audit and reduce installed packages
-The `package-lock.json` is ~3000 lines of resolved transitive dependencies. Review whether all direct dependencies are still needed (e.g. `tsx` is a runtime dev tool bundled as a production dependency). Move dev-only packages out of `dependencies`, run `npm prune`, and consider lighter alternatives where possible to shrink the dependency tree.
+### ~~1. Audit and reduce installed packages~~
+~~The `package-lock.json` is ~3000 lines of resolved transitive dependencies. Review whether all direct dependencies are still needed (e.g. `tsx` is a runtime dev tool bundled as a production dependency). Move dev-only packages out of `dependencies`, run `npm prune`, and consider lighter alternatives where possible to shrink the dependency tree.~~
+Done — moved `tsx` from `dependencies` to `devDependencies` (it is only used as a CLI tool in the `dev:server` script, not imported in source code). Remaining dependencies (`express`) are correctly classified. All checks pass (typecheck, tests, build).
 
 ### 2. Expand test coverage
 Current tests cover only `verify.ts` and `recipes.ts` (~46 lines of test code, estimated <15% coverage). Missing test areas:


### PR DESCRIPTION
## Summary
Reclassified `tsx` as a development dependency since it is only used as a CLI tool in the `dev:server` script and is not imported anywhere in the source code. This reduces the production dependency footprint.

## Changes
- Moved `tsx` from `dependencies` to `devDependencies` in `package.json`
- Updated `package-lock.json` to reflect the reclassification and mark all transitive dependencies of `tsx` (and other dev tools) with `"dev": true`
- Updated `todo.md` to mark the "Audit and reduce installed packages" task as complete with implementation notes

## Details
- `tsx` is a TypeScript execution tool used only during development (in the `dev:server` npm script)
- It is never imported or used in production code
- The only production dependency is now `express`, which is correctly classified
- All type checking, tests, and build processes continue to pass
- This change reduces the production dependency tree and improves clarity of the project's actual runtime requirements

https://claude.ai/code/session_01KSXb4NtVADm4ftxcTetSvj