### PR TITLE
Add CI/CD workflow for automated testing and security audits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [20, 22]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+  security-audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Security audit
+        run: npm audit --omit=dev


### PR DESCRIPTION
## Summary
This PR introduces a GitHub Actions CI/CD workflow to automate testing, type checking, building, and security audits on every push to main and pull request.

## Key Changes
- **CI Job**: Runs on Node.js 20 and 22 to ensure compatibility across versions
  - Installs dependencies using `npm ci`
  - Runs typecheck to catch type errors
  - Executes test suite
  - Builds the project
  
- **Security Audit Job**: Dedicated job that runs security audits on production dependencies
  - Uses Node.js 22
  - Runs `npm audit --omit=dev` to check for vulnerabilities in production code only

## Implementation Details
- Workflow triggers on pushes to `main` branch and all pull requests targeting `main`
- Uses `actions/checkout@v4` and `actions/setup-node@v4` for reliable action versions
- Leverages npm caching to speed up dependency installation
- Separate security audit job allows it to run independently and fail without blocking other checks if needed

https://claude.ai/code/session_01DNppKypYQXYzy3M6iwuoU2