### PR TITLE
Add complex multi-material crafting recipes

### DIFF
--- a/src/server/challenge.ts
+++ b/src/server/challenge.ts
@@ -45,7 +45,7 @@ export function consumeChallenge(challengeId: string): string | null {
   return entry.recipeId;
 }
 
-/** Pick 2-3 random item ids that are NOT in the required set. */
+/** Pick 3-5 random item ids that are NOT in the required set. */
 function getDistractorItems(needed: Set<ItemId>): ItemId[] {
   const all = new Set<ItemId>();
   for (const r of RECIPES) {
@@ -56,7 +56,7 @@ function getDistractorItems(needed: Set<ItemId>): ItemId[] {
     }
   }
   const pool = [...all];
-  const count = Math.min(pool.length, 2 + Math.floor(Math.random() * 2));
+  const count = Math.min(pool.length, 3 + Math.floor(Math.random() * 3));
   return shuffle(pool).slice(0, count);
 }
 

--- a/src/server/verify.test.ts
+++ b/src/server/verify.test.ts
@@ -145,7 +145,7 @@ describe("verifyAnswer", () => {
       // We can't control which recipe is selected, so we create many challenges
       // and find one matching this recipe
       let found = false;
-      for (let attempt = 0; attempt < 200; attempt++) {
+      for (let attempt = 0; attempt < 500; attempt++) {
         const challenge = createChallenge();
         const recipeName = challenge.prompt.replace("Craft: ", "");
         if (recipeName === recipe.resultName) {
@@ -160,7 +160,7 @@ describe("verifyAnswer", () => {
         // Consume unused challenges to not leak memory
         // (they expire naturally, but clean up)
       }
-      // With 8 recipes and 200 attempts, probability of missing one is negligible
+      // With 18 recipes and 500 attempts, probability of missing one is negligible
       expect(found).toBe(true);
     }
   });

--- a/src/shared/recipes.test.ts
+++ b/src/shared/recipes.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from "vitest";
 import { RECIPES } from "./recipes.js";
 
 describe("recipes", () => {
-  it("should have at least one recipe", () => {
-    expect(RECIPES.length).toBeGreaterThan(0);
+  it("should have at least 15 recipes", () => {
+    expect(RECIPES.length).toBeGreaterThanOrEqual(15);
   });
 
   it("every recipe has a 3x3 pattern", () => {

--- a/src/shared/recipes.ts
+++ b/src/shared/recipes.ts
@@ -93,4 +93,115 @@ export const RECIPES: Recipe[] = [
       ["cobblestone", "cobblestone", "cobblestone"],
     ],
   },
+  // --- Multi-material recipes below ---
+  {
+    id: "iron_pickaxe",
+    result: "iron_pickaxe",
+    resultName: "Iron Pickaxe",
+    count: 1,
+    pattern: [
+      ["iron_ingot", "iron_ingot", "iron_ingot"],
+      [null, "stick", null],
+      [null, "stick", null],
+    ],
+  },
+  {
+    id: "diamond_sword",
+    result: "diamond_sword",
+    resultName: "Diamond Sword",
+    count: 1,
+    pattern: [
+      [null, "diamond", null],
+      [null, "diamond", null],
+      [null, "stick", null],
+    ],
+  },
+  {
+    id: "bow",
+    result: "bow",
+    resultName: "Bow",
+    count: 1,
+    pattern: [
+      [null, "stick", "string"],
+      ["stick", null, "string"],
+      [null, "stick", "string"],
+    ],
+  },
+  {
+    id: "fishing_rod",
+    result: "fishing_rod",
+    resultName: "Fishing Rod",
+    count: 1,
+    pattern: [
+      [null, null, "stick"],
+      [null, "stick", "string"],
+      ["stick", null, "string"],
+    ],
+  },
+  {
+    id: "bookshelf",
+    result: "bookshelf",
+    resultName: "Bookshelf",
+    count: 1,
+    pattern: [
+      ["oak_planks", "oak_planks", "oak_planks"],
+      ["book", "book", "book"],
+      ["oak_planks", "oak_planks", "oak_planks"],
+    ],
+  },
+  {
+    id: "iron_helmet",
+    result: "iron_helmet",
+    resultName: "Iron Helmet",
+    count: 1,
+    pattern: [
+      ["iron_ingot", "iron_ingot", "iron_ingot"],
+      ["iron_ingot", null, "iron_ingot"],
+      [null, null, null],
+    ],
+  },
+  {
+    id: "ladder",
+    result: "ladder",
+    resultName: "Ladder",
+    count: 3,
+    pattern: [
+      ["stick", null, "stick"],
+      ["stick", "stick", "stick"],
+      ["stick", null, "stick"],
+    ],
+  },
+  {
+    id: "stone_stairs",
+    result: "stone_stairs",
+    resultName: "Stone Stairs",
+    count: 4,
+    pattern: [
+      ["stone", null, null],
+      ["stone", "stone", null],
+      ["stone", "stone", "stone"],
+    ],
+  },
+  {
+    id: "piston",
+    result: "piston",
+    resultName: "Piston",
+    count: 1,
+    pattern: [
+      ["oak_planks", "oak_planks", "oak_planks"],
+      ["cobblestone", "iron_ingot", "cobblestone"],
+      ["cobblestone", "redstone", "cobblestone"],
+    ],
+  },
+  {
+    id: "golden_apple",
+    result: "golden_apple",
+    resultName: "Golden Apple",
+    count: 1,
+    pattern: [
+      ["gold_ingot", "gold_ingot", "gold_ingot"],
+      ["gold_ingot", "apple", "gold_ingot"],
+      ["gold_ingot", "gold_ingot", "gold_ingot"],
+    ],
+  },
 ];


### PR DESCRIPTION
## Summary
- Add 10 new multi-material crafting recipes (iron pickaxe, diamond sword, bow, fishing rod, bookshelf, iron helmet, ladder, stone stairs, piston, golden apple) using new materials (iron_ingot, diamond, string, book, stone, redstone, gold_ingot, apple)
- Increase distractor item count from 2-3 to 3-5 for harder challenges
- Keep all 8 original easy recipes for variety
- Update tests: recipe count assertion, increase verify attempt count to 500

## Test plan
- [x] All 26 tests pass (`npx vitest run`)
- [x] TypeScript typecheck passes (`npx tsc --noEmit`)
- [x] Each new recipe uses correct 3x3 Minecraft patterns
- [x] Distractor count updated from `2 + rand(2)` to `3 + rand(3)`

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)