### PR TITLE
Replace HMAC cookie with JWT (ES256 asymmetric signing)

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -20,7 +20,7 @@ The simplest way — no build tools required.
     element: document.getElementById("captcha"),
     apiUrl: "https://your-api.com", // where the verification server runs
     onSuccess: function (result) {
-      // captcha solved — the server has set an httpOnly cookie
+      // captcha solved — the server has set an httpOnly cookie containing a JWT
       document.getElementById("my-form").submit();
     },
     onFailure: function (result) {
@@ -93,11 +93,21 @@ The verification server is a standalone Express app. Run it alongside your exist
 ### Option A: Standalone server
 
 ```bash
-# Set a secret for cookie signing (random default is used otherwise)
-export CAPTCHA_SECRET="your-secret-here"
+# Provide ES256 key files for persistent JWT signing (recommended for production)
+export CAPTCHA_PRIVATE_KEY_PATH="/path/to/ec-private.pem"
+export CAPTCHA_PUBLIC_KEY_PATH="/path/to/ec-public.pem"
 export PORT=3000
 
 npx tsx src/server/index.ts
+```
+
+In development, if no key paths are set an ephemeral key pair is generated automatically (tokens will not survive restarts).
+
+To generate an ES256 key pair:
+
+```bash
+openssl ecparam -name prime256v1 -genkey -noout -out ec-private.pem
+openssl ec -in ec-private.pem -pubout -out ec-public.pem
 ```
 
 ### Option B: Mount into an existing Express app
@@ -120,23 +130,28 @@ app.listen(8080);
 import { createChallenge } from "minecraft-captcha/server";
 import {
   verifyAnswer,
-  generateCookieValue,
-  validateCookie,
+  generateToken,
+  validateToken,
+  initKeys,
 } from "minecraft-captcha/server";
 
+// Initialize keys before handling requests
+await initKeys();
+
 // In your own route handler:
-app.post("/my-captcha-check", (req, res) => {
+app.post("/my-captcha-check", async (req, res) => {
   const result = verifyAnswer(req.body);
   if (result.success) {
-    res.cookie("mc_captcha", generateCookieValue(), { httpOnly: true });
+    const token = await generateToken();
+    res.cookie("mc_captcha", token, { httpOnly: true });
   }
   res.json(result);
 });
 
 // In a middleware to protect a route:
-app.use("/protected", (req, res, next) => {
+app.use("/protected", async (req, res, next) => {
   const token = req.cookies?.mc_captcha;
-  if (!token || !validateCookie(token)) {
+  if (!token || !(await validateToken(token))) {
     return res.status(403).json({ error: "Captcha required" });
   }
   next();
@@ -147,22 +162,72 @@ app.use("/protected", (req, res, next) => {
 
 ## 4. Cookie Behavior
 
-On successful verification, the server sets an `mc_captcha` httpOnly cookie:
+On successful verification, the server sets an `mc_captcha` httpOnly cookie containing a signed JWT:
 
-| Property | Value                 |
-| -------- | --------------------- |
-| Name     | `mc_captcha`          |
-| HttpOnly | `true`                |
-| Secure   | `true` in production  |
-| SameSite | `strict`              |
-| Max-Age  | 1 hour                |
-| Content  | HMAC-signed timestamp |
+| Property | Value                                 |
+| -------- | ------------------------------------- |
+| Name     | `mc_captcha`                          |
+| HttpOnly | `true`                                |
+| Secure   | `true` in production                  |
+| SameSite | `strict`                              |
+| Max-Age  | 1 hour                                |
+| Content  | ES256-signed JWT (iss, iat, exp, jti) |
 
-Your backend middleware can validate this cookie using `validateCookie()` to decide whether the user has passed the captcha.
+The JWT contains the following claims:
+
+| Claim | Description                       |
+| ----- | --------------------------------- |
+| `iss` | `"minecraft-captcha"`             |
+| `iat` | Issued-at timestamp (seconds)     |
+| `exp` | Expiration timestamp (iat + 3600) |
+| `jti` | Unique token identifier (UUID)    |
+
+Your backend can validate this cookie using `validateToken()` or by verifying the JWT independently with the public key.
 
 ---
 
-## 5. Configuration Summary
+## 5. Public Key Endpoint
+
+The server exposes a `GET /api/captcha/public-key` endpoint that returns the public key in JWK format. This allows external services to verify captcha JWTs without sharing a secret.
+
+```bash
+curl https://your-api.com/api/captcha/public-key
+```
+
+Response:
+
+```json
+{
+  "kty": "EC",
+  "crv": "P-256",
+  "x": "...",
+  "y": "...",
+  "alg": "ES256"
+}
+```
+
+### Verifying a JWT externally (Node.js example)
+
+```ts
+import { jwtVerify, importJWK } from "jose";
+
+// Fetch the public key once and cache it
+const res = await fetch("https://your-api.com/api/captcha/public-key");
+const jwk = await res.json();
+const publicKey = await importJWK(jwk, "ES256");
+
+// Verify a token from the mc_captcha cookie
+const { payload } = await jwtVerify(token, publicKey, {
+  issuer: "minecraft-captcha",
+  algorithms: ["ES256"],
+});
+
+console.log("Token is valid, issued at:", new Date(payload.iat! * 1000));
+```
+
+---
+
+## 6. Configuration Summary
 
 ### Widget options
 
@@ -175,8 +240,9 @@ Your backend middleware can validate this cookie using `validateCookie()` to dec
 
 ### Server environment variables
 
-| Variable         | Default | Description                                  |
-| ---------------- | ------- | -------------------------------------------- |
-| `PORT`           | `3000`  | HTTP port for the standalone server          |
-| `CAPTCHA_SECRET` | random  | HMAC secret for cookie signing               |
-| `NODE_ENV`       | —       | Set to `production` to enable secure cookies |
+| Variable                   | Default | Description                                  |
+| -------------------------- | ------- | -------------------------------------------- |
+| `PORT`                     | `3000`  | HTTP port for the standalone server          |
+| `CAPTCHA_PRIVATE_KEY_PATH` | —       | Path to ES256 private key PEM file           |
+| `CAPTCHA_PUBLIC_KEY_PATH`  | —       | Path to ES256 public key PEM file            |
+| `NODE_ENV`                 | —       | Set to `production` to enable secure cookies |

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "express": "^5.0.0"
+        "express": "^5.0.0",
+        "jose": "^6.1.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
@@ -3191,6 +3192,14 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/js-tokens": {
       "version": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
     "husky": "^9.1.7",
+    "jsdom": "^28.0.0",
     "lint-staged": "^16.2.7",
     "prettier": "^3.8.1",
-    "jsdom": "^28.0.0",
     "tsx": "^4.0.0",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.54.0",
@@ -68,6 +68,7 @@
     ]
   },
   "dependencies": {
-    "express": "^5.0.0"
+    "express": "^5.0.0",
+    "jose": "^6.1.3"
   }
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -3,7 +3,9 @@ import type { Server } from "node:http";
 import { createChallenge } from "./challenge.js";
 import {
   verifyAnswer,
-  generateCookieValue,
+  generateToken,
+  getPublicKeyJwk,
+  initKeys,
   COOKIE_NAME,
   COOKIE_MAX_AGE,
 } from "./verify.js";
@@ -104,29 +106,34 @@ app.post("/api/captcha/challenge", rateLimit, (_req, res) => {
 });
 
 /** Verify the user's crafting answer */
-app.post("/api/captcha/verify", rateLimit, (req, res) => {
+app.post("/api/captcha/verify", rateLimit, async (req, res) => {
   const answer = req.body as CaptchaAnswer;
   if (!answer?.challengeId || !answer?.grid) {
     res.status(400).json({ success: false, message: "Invalid request body" });
     return;
   }
 
-  if (typeof answer.challengeId !== "string" || answer.challengeId.length > 64) {
+  if (
+    typeof answer.challengeId !== "string" ||
+    answer.challengeId.length > 64
+  ) {
     res.status(400).json({ success: false, message: "Invalid challengeId" });
     return;
   }
 
   if (!isValidGrid(answer.grid)) {
-    res
-      .status(400)
-      .json({ success: false, message: "Grid must be a 3x3 array of valid item IDs or null" });
+    res.status(400).json({
+      success: false,
+      message: "Grid must be a 3x3 array of valid item IDs or null",
+    });
     return;
   }
 
   const result = verifyAnswer(answer);
 
   if (result.success) {
-    res.cookie(COOKIE_NAME, generateCookieValue(), {
+    const token = await generateToken();
+    res.cookie(COOKIE_NAME, token, {
       httpOnly: true,
       secure: process.env.NODE_ENV === "production",
       sameSite: "strict",
@@ -136,6 +143,11 @@ app.post("/api/captcha/verify", rateLimit, (req, res) => {
   }
 
   res.json(result);
+});
+
+/** Serve the public key in JWK format for external JWT verification. */
+app.get("/api/captcha/public-key", (_req, res) => {
+  res.json(getPublicKeyJwk());
 });
 
 // ---------------------------------------------------------------------------
@@ -152,11 +164,16 @@ function shutdown(signal: string) {
   });
 }
 
-server = app.listen(PORT, () => {
-  console.log(`Minecraft Captcha server running on http://localhost:${PORT}`);
-});
+async function start() {
+  await initKeys();
+  server = app.listen(PORT, () => {
+    console.log(`Minecraft Captcha server running on http://localhost:${PORT}`);
+  });
 
-process.on("SIGTERM", () => shutdown("SIGTERM"));
-process.on("SIGINT", () => shutdown("SIGINT"));
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+  process.on("SIGINT", () => shutdown("SIGINT"));
+}
+
+start();
 
 export { app };


### PR DESCRIPTION
## Summary

- Replaces symmetric HMAC-SHA256 cookie scheme with asymmetric JWT signing (ES256) via the `jose` library
- Adds `GET /api/captcha/public-key` endpoint so external services can verify captcha tokens with only the public key
- Replaces `CAPTCHA_SECRET` env var with `CAPTCHA_PRIVATE_KEY_PATH` / `CAPTCHA_PUBLIC_KEY_PATH` for persistent key files (ephemeral keys auto-generated in dev)

Closes #21

## Changes

- **`src/server/verify.ts`**: Rewrote `generateCookieValue()` → `generateToken()` (async, returns signed JWT with iss/iat/exp/jti claims) and `validateCookie()` → `validateToken()` (async, verifies with public key). Added `initKeys()` for key pair loading/generation.
- **`src/server/index.ts`**: Made verify route async, added public-key endpoint, calls `initKeys()` at startup.
- **`src/server/verify.test.ts`**: Updated tests for async JWT functions. Added tests for tampered tokens, wrong-key tokens, expired tokens, JWK export, and JWT claim structure.
- **`INTEGRATION.md`**: Updated docs with JWT verification examples, public-key endpoint, and new env vars.
- **`package.json`**: Added `jose` dependency.

## Test plan

- [x] All 48 existing tests pass (`npm test`)
- [x] TypeScript typecheck passes (`npm run typecheck`)
- [ ] Verify ephemeral key generation works in dev (no env vars set)
- [ ] Verify PEM key loading works with `CAPTCHA_PRIVATE_KEY_PATH` / `CAPTCHA_PUBLIC_KEY_PATH`
- [ ] Verify `GET /api/captcha/public-key` returns valid JWK
- [ ] Verify cookie now contains a valid JWT after solving captcha

🤖 Generated with [Claude Code](https://claude.com/claude-code)