### PR TITLE
Replace text item labels with Minecraft-style sprite icons

### DIFF
--- a/src/client/CraftingTable.ts
+++ b/src/client/CraftingTable.ts
@@ -4,6 +4,7 @@ import type {
   CraftingGrid,
   ItemId,
 } from "../shared/types.js";
+import { createItemIcon } from "./itemAssets.js";
 
 /**
  * Renders a 3x3 Minecraft crafting grid with drag-and-drop item placement.
@@ -84,7 +85,7 @@ export class CraftingTable {
     el.className = "mc-item";
     el.draggable = true;
     el.dataset.item = itemId;
-    el.textContent = itemId.replace(/_/g, " ");
+    el.appendChild(createItemIcon(itemId));
     el.addEventListener("dragstart", (e) => {
       e.dataTransfer?.setData("text/plain", itemId);
     });
@@ -104,13 +105,16 @@ export class CraftingTable {
       slot.classList.remove("mc-slot--hover");
       const itemId = e.dataTransfer?.getData("text/plain") ?? null;
       this.grid[row][col] = itemId;
-      slot.textContent = itemId ? itemId.replace(/_/g, " ") : "";
+      slot.innerHTML = "";
+      if (itemId) {
+        slot.appendChild(createItemIcon(itemId));
+      }
       slot.classList.toggle("mc-slot--filled", itemId !== null);
     });
     // Click to clear
     slot.addEventListener("click", () => {
       this.grid[row][col] = null;
-      slot.textContent = "";
+      slot.innerHTML = "";
       slot.classList.remove("mc-slot--filled");
     });
   }

--- a/src/client/itemAssets.ts
+++ b/src/client/itemAssets.ts
@@ -1,0 +1,64 @@
+/**
+ * Minecraft-style item visual mappings.
+ * Maps item IDs to emoji/icon representations with styling info.
+ */
+
+export interface ItemVisual {
+  /** Emoji or character to display */
+  icon: string;
+  /** Background color for the icon container */
+  bg: string;
+  /** Human-readable display name (for tooltip) */
+  label: string;
+}
+
+const ITEM_VISUALS: Record<string, ItemVisual> = {
+  oak_planks: { icon: "🪵", bg: "#b5884e", label: "Oak Planks" },
+  stick: { icon: "🥢", bg: "#8b6914", label: "Stick" },
+  coal: { icon: "⬛", bg: "#2a2a2a", label: "Coal" },
+  cobblestone: { icon: "🪨", bg: "#7a7a7a", label: "Cobblestone" },
+  iron_ingot: { icon: "⬜", bg: "#d4d4d4", label: "Iron Ingot" },
+  gold_ingot: { icon: "🟨", bg: "#ffd700", label: "Gold Ingot" },
+  diamond: { icon: "💎", bg: "#5ee8e4", label: "Diamond" },
+  redstone: { icon: "🔴", bg: "#c41a1a", label: "Redstone" },
+  string: { icon: "🧵", bg: "#e0e0e0", label: "String" },
+  leather: { icon: "🟫", bg: "#8b5a2b", label: "Leather" },
+  wooden_pickaxe: { icon: "⛏️", bg: "#b5884e", label: "Wooden Pickaxe" },
+  wooden_sword: { icon: "🗡️", bg: "#b5884e", label: "Wooden Sword" },
+  wooden_shovel: { icon: "🪏", bg: "#b5884e", label: "Wooden Shovel" },
+  crafting_table: { icon: "🔨", bg: "#b5884e", label: "Crafting Table" },
+  torch: { icon: "🔥", bg: "#ffa500", label: "Torch" },
+  chest: { icon: "📦", bg: "#b5884e", label: "Chest" },
+  furnace: { icon: "🔲", bg: "#7a7a7a", label: "Furnace" },
+};
+
+/** Default visual for unknown items */
+const DEFAULT_VISUAL: ItemVisual = {
+  icon: "❓",
+  bg: "#555",
+  label: "Unknown",
+};
+
+/** Get the visual representation for an item ID. */
+export function getItemVisual(itemId: string): ItemVisual {
+  return (
+    ITEM_VISUALS[itemId] ?? {
+      ...DEFAULT_VISUAL,
+      label: itemId.replace(/_/g, " "),
+    }
+  );
+}
+
+/**
+ * Create an icon element (span) for the given item ID.
+ * The span contains the emoji, has a background color, and a title tooltip.
+ */
+export function createItemIcon(itemId: string): HTMLSpanElement {
+  const visual = getItemVisual(itemId);
+  const span = document.createElement("span");
+  span.className = "mc-item-icon";
+  span.textContent = visual.icon;
+  span.title = visual.label;
+  span.style.backgroundColor = visual.bg;
+  return span;
+}

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -81,15 +81,49 @@
   border: 2px solid #373737;
   border-top-color: #aaa;
   border-left-color: #aaa;
-  padding: 6px 10px;
+  padding: 4px;
   font-size: 11px;
   color: #fff;
   cursor: grab;
   text-shadow: 1px 1px 0 #333;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .mc-item:active {
   cursor: grabbing;
+}
+
+.mc-item-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  font-size: 22px;
+  line-height: 1;
+  border-radius: 2px;
+  image-rendering: pixelated;
+  position: relative;
+}
+
+.mc-item-icon[title]:hover::after {
+  content: attr(title);
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: #1a1a2e;
+  color: #fff;
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 2px;
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 10;
+  border: 1px solid #5555ff;
+  font-family: "Courier New", monospace;
 }
 
 .mc-craft-btn {


### PR DESCRIPTION
## Summary
- Created `src/client/itemAssets.ts` with emoji-based visual mappings for all crafting items (oak_planks, stick, coal, cobblestone, etc.)
- Updated `CraftingTable.ts` to render icon spans with emoji + colored backgrounds instead of plain text labels
- Added CSS styling for icon elements with hover tooltips showing item names
- Updated tests to verify icon rendering instead of plain text assertions, and fixed pre-existing `as any` lint violations

## Test plan
- [x] All 46 existing tests pass (`npx vitest run`)
- [x] TypeScript typecheck passes (`npx tsc --noEmit`)
- [x] ESLint + Prettier pass (pre-commit hooks)
- [ ] Manual verification: drag items to grid slots, verify emoji icons appear
- [ ] Manual verification: hover over icons to see item name tooltips
- [ ] Manual verification: click slots to clear icons

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)